### PR TITLE
Fix KuzzleError instanciation

### DIFF
--- a/lib/src/kuzzle.dart
+++ b/lib/src/kuzzle.dart
@@ -397,7 +397,9 @@ class Kuzzle extends KuzzleEventEmitter {
 
       emit(ProtocolEvents.DISCARDED, [request]);
       return Future.error(KuzzleError(
-          'Unable to execute request: not connected to a Kuzzle server.'));
+          'not_connected',
+          'Unable to execute request: not connected to a Kuzzle server.',
+        503));
     }
 
     _requests.add(request.requestId);


### PR DESCRIPTION
## What does this PR do ?

Fix `KuzzleError` instantiation when not connected to Kuzzle
