### PR TITLE
Export HttpProtocol

### DIFF
--- a/.ci/doc/templates/without-ctor.tpl.dart
+++ b/.ci/doc/templates/without-ctor.tpl.dart
@@ -1,5 +1,4 @@
 import 'package:kuzzle/kuzzle.dart';
-import 'package:kuzzle/src/protocols/http.dart';
 
 void main() {
   [snippet-code]

--- a/lib/kuzzle.dart
+++ b/lib/kuzzle.dart
@@ -17,6 +17,7 @@ export 'src/kuzzle/response.dart';
 export 'src/kuzzle/role.dart';
 export 'src/kuzzle/user.dart';
 export 'src/protocols/abstract.dart';
+export 'src/protocols/http.dart';
 export 'src/protocols/websocket.dart';
 export 'src/search_result/documents.dart';
 export 'src/search_result/profiles.dart';


### PR DESCRIPTION
## What does this PR do ?

Forgot to export the HttpProtocol class in the main `kuzzle.dart` file

### How should this be manually tested?

```dart
import 'package:kuzzle/kuzzle.dart';

void main() {
  final proto = HttpProtocol(
    Uri(
      scheme: 'http',
      host: 'localhost',
      port: 7512,
    ),
  );
}
```

`HttpProtocol` should not be unknown.