### PR TITLE
Add custom properties to a KuzzleRequest

### DIFF
--- a/doc/2/core-classes/kuzzle/query/index.md
+++ b/doc/2/core-classes/kuzzle/query/index.md
@@ -24,7 +24,7 @@ This is a low-level method, exposed to allow advanced SDK users to bypass high-l
 
 | Argument  | Type              | Description            |
 | --------- | ----------------- | ---------------------- |
-| `request` | <pre>KuzzleRequest</pre> | API request    |
+| `request` | <pre>[KuzzleRequest](/sdk/dart/2/core-classes/request)</pre> | API request    |
 | `volatile`   | <pre>Map<String, dynamic></pre> | Additional information to send to Kuzzle |
 | `queueable`   | <pre>bool</pre> | If true, queues the request during downtime, until connected to Kuzzle again |
 

--- a/doc/2/core-classes/request/index.md
+++ b/doc/2/core-classes/request/index.md
@@ -1,0 +1,7 @@
+---
+code: true
+type: branch
+title: KuzzleRequest
+description: KuzzleRequest object documentation
+order: 0
+---

--- a/doc/2/core-classes/request/introduction/index.md
+++ b/doc/2/core-classes/request/introduction/index.md
@@ -1,0 +1,36 @@
+---
+code: false
+type: page
+title: Introduction
+description: KuzzleRequest object description
+order: 0
+---
+
+## KuzzleRequest
+
+`KuzzleRequest` is a **serializable** class representing a raw Kuzzle request.
+
+
+## Properties
+
+| Property | Type | Description |
+|--- |--- |--- |
+| `action` | <pre>String</pre> | Executed Kuzzle API controller's action `
+| `body` | <pre>Map<String, dynamic> body</pre> |
+| `collection` | <pre>String</pre> | Impacted collection |
+| `controller` | <pre>String</pre> | Executed Kuzzle API controller |
+| `index` | <pre>String</pre> | Impacted index |
+| `jwt` | <pre>String</pre> | Authentication token |
+| `lang` | <pre>String</pre> | ES lang |
+| `requestId` | <pre>String</pre> | Request unique identifier |
+| `waitForRefresh` | <pre>bool</pre> | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing |
+| `volatile` | <pre>Map<String, dynamic></pre> | Volatile data |
+| `from`     | <pre>int</pre><br/>(`0`)    | Offset of the first document to fetch |
+| `size`     | <pre>int</pre><br/>(`10`)   | Maximum number of documents to retrieve per page |
+| `scroll`   | <pre>String</pre><br/>(`""`)    | When set, gets a forward-only cursor having its ttl set to the given value (ie `1s`; cf [elasticsearch time limits](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/common-options.html#time-units)) |
+| `scrollId` | <pre>String</pre> | The scrollId if using scroll option |
+| `sort` | <pre>List<dynamic></pre> | Contains a list of fields, used to [sort search results](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/search-request-sort.html), in order of importance. |
+
+## Overrided operators
+
+The `[]` and `[]=` are overrided so you can dynamically add any args you want to this class and it will be taken in consideration in the request sent to Kuzzle.

--- a/lib/src/kuzzle/request.dart
+++ b/lib/src/kuzzle/request.dart
@@ -111,8 +111,13 @@ class KuzzleRequest {
     includeKuzzleMeta = data['includeKuzzleMeta'] as bool;
   }
 
+  final Map<String, dynamic> _args = {};
+
+  dynamic operator [](String key) => _args[key];
+  void operator []=(String key, dynamic value) => _args[key] = value;
+
   Map toJson() {
-    final map = <String, dynamic>{};
+    final map = _args;
 
     if (action != null) {
       map['action'] = action;


### PR DESCRIPTION
## What does this PR do ?

Override the operators `[]` and `[]=` to `KuzzleRequest` object to be able to add custom properties to the request outside of the body.

### How should this be manually tested?

```dart
final request = KuzzleRequest(controller: 'test', action: 'test', body: {});
request['custom'] = 'foo';
final res = await kuzzle.query(request);
```

The `custom` field should be sent to kuzzle in the request.

### Other changes

Add the documentation for `KuzzleRequest`