### PR TITLE
Add HTTP Browser support

### DIFF
--- a/.ci/doc/project/pubspec.yaml
+++ b/.ci/doc/project/pubspec.yaml
@@ -2,6 +2,9 @@ name: Tests
 version: 1.0.0
 description: Dart SDK doc snippet test project
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   kuzzle:
     path: /mnt/

--- a/lib/src/protocols/http.dart
+++ b/lib/src/protocols/http.dart
@@ -1,21 +1,17 @@
 import 'dart:convert';
-import 'dart:io';
 
-import 'package:http/io_client.dart';
+import 'package:http/http.dart';
 import 'package:kuzzle/src/kuzzle/request.dart';
 import 'package:kuzzle/src/kuzzle/response.dart';
 import 'package:kuzzle/src/protocols/abstract.dart';
+import 'package:kuzzle/src/protocols/http_client_browser.dart' if (dart.library.web) 'package:kuzzle/src/protocols/http_client_io.dart';
 
 class HttpProtocol extends KuzzleProtocol {
   HttpProtocol(Uri uri, {bool acceptBadCertificate = false}) : super(uri) {
-    _client = HttpClient()
-      ..badCertificateCallback =
-          ((cert, host, port) => acceptBadCertificate);
-    _ioClient = IOClient(_client);
+    _ioClient = createHttpClient(acceptBadCertificate: acceptBadCertificate);
   }
 
-  HttpClient _client;
-  IOClient _ioClient;
+  BaseClient _ioClient;
 
   @override
   Future<void> connect() async {

--- a/lib/src/protocols/http.dart
+++ b/lib/src/protocols/http.dart
@@ -4,7 +4,8 @@ import 'package:http/http.dart';
 import 'package:kuzzle/src/kuzzle/request.dart';
 import 'package:kuzzle/src/kuzzle/response.dart';
 import 'package:kuzzle/src/protocols/abstract.dart';
-import 'package:kuzzle/src/protocols/http_client_io.dart' if (dart.library.html) 'package:kuzzle/src/protocols/http_client_browser.dart';
+import 'package:kuzzle/src/protocols/http_client_io.dart'
+    if (dart.library.html) 'package:kuzzle/src/protocols/http_client_browser.dart';
 
 class HttpProtocol extends KuzzleProtocol {
   HttpProtocol(Uri uri, {bool acceptBadCertificate = false}) : super(uri) {

--- a/lib/src/protocols/http.dart
+++ b/lib/src/protocols/http.dart
@@ -4,7 +4,7 @@ import 'package:http/http.dart';
 import 'package:kuzzle/src/kuzzle/request.dart';
 import 'package:kuzzle/src/kuzzle/response.dart';
 import 'package:kuzzle/src/protocols/abstract.dart';
-import 'package:kuzzle/src/protocols/http_client_browser.dart' if (dart.library.web) 'package:kuzzle/src/protocols/http_client_io.dart';
+import 'package:kuzzle/src/protocols/http_client_io.dart' if (dart.library.html) 'package:kuzzle/src/protocols/http_client_browser.dart';
 
 class HttpProtocol extends KuzzleProtocol {
   HttpProtocol(Uri uri, {bool acceptBadCertificate = false}) : super(uri) {

--- a/lib/src/protocols/http_client_browser.dart
+++ b/lib/src/protocols/http_client_browser.dart
@@ -1,0 +1,6 @@
+import 'package:http/browser_client.dart';
+import 'package:http/http.dart';
+
+BaseClient createHttpClient({bool acceptBadCertificate = false}) {
+  return BrowserClient();
+}

--- a/lib/src/protocols/http_client_io.dart
+++ b/lib/src/protocols/http_client_io.dart
@@ -1,0 +1,10 @@
+import 'dart:io';
+
+import 'package:http/http.dart';
+import 'package:http/io_client.dart';
+
+BaseClient createHttpClient({bool acceptBadCertificate = false}) {
+  final client = HttpClient()
+    ..badCertificateCallback = ((cert, host, port) => acceptBadCertificate);
+  return IOClient(client);
+}

--- a/lib/src/protocols/http_client_io.dart
+++ b/lib/src/protocols/http_client_io.dart
@@ -4,7 +4,6 @@ import 'package:http/http.dart';
 import 'package:http/io_client.dart';
 
 BaseClient createHttpClient({bool acceptBadCertificate = false}) {
-  print('io');
   final client = HttpClient()
     ..badCertificateCallback = ((cert, host, port) => acceptBadCertificate);
   return IOClient(client);

--- a/lib/src/protocols/http_client_io.dart
+++ b/lib/src/protocols/http_client_io.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart';
 import 'package:http/io_client.dart';
 
 BaseClient createHttpClient({bool acceptBadCertificate = false}) {
+  print('io');
   final client = HttpClient()
     ..badCertificateCallback = ((cert, host, port) => acceptBadCertificate);
   return IOClient(client);


### PR DESCRIPTION
## What does this PR do ?

Add HTTP for webbrowser support.
The HTTP call will automatically choose to use io or browser support, nothing has to be changed
