### PR TITLE
Fix autoreconnect

### DIFF
--- a/lib/src/kuzzle.dart
+++ b/lib/src/kuzzle.dart
@@ -51,8 +51,8 @@ class Kuzzle extends KuzzleEventEmitter {
     }
 
     globalVolatile ??= <String, dynamic>{};
-    queueTTL ??= Duration(minutes: 2);
-    replayInterval ??= Duration(milliseconds: 10);
+    queueTTL ??= const Duration(minutes: 2);
+    replayInterval ??= const Duration(milliseconds: 10);
 
     server = ServerController(this);
     bulk = BulkController(this);
@@ -153,12 +153,7 @@ class Kuzzle extends KuzzleEventEmitter {
   /// Common volatile data, will be sent to all future requests
   Map<String, dynamic> globalVolatile;
 
-  final List<String> _requests = List();
-
-  bool get autoReconnect => protocol.autoReconnect;
-  set autoReconnect(bool value) {
-    protocol.autoReconnect = value;
-  }
+  final List<String> _requests = [];
 
   final Map<String, KuzzleController> _controllers =
       <String, KuzzleController>{};
@@ -174,7 +169,7 @@ class Kuzzle extends KuzzleEventEmitter {
     if (protocol.state == KuzzleProtocolState.connecting) {
       final completer = Completer<void>();
 
-      // todo: handle reconnect event
+      protocol.once(ProtocolEvents.RECONNECT, completer.complete);
       protocol.once(ProtocolEvents.CONNECT, completer.complete);
 
       return completer.future;

--- a/lib/src/protocols/websocket_browser.dart
+++ b/lib/src/protocols/websocket_browser.dart
@@ -15,8 +15,9 @@ class KuzzleWebSocket extends KuzzleProtocol {
     bool autoReconnect = true,
     Duration reconnectionDelay,
     this.pingInterval,
-  }) : super(uri,
-            autoReconnect: autoReconnect, reconnectionDelay: reconnectionDelay);
+  }) : super(
+          uri,
+        );
 
   String _lastUrl;
   WebSocket _webSocket;
@@ -64,7 +65,6 @@ class KuzzleWebSocket extends KuzzleProtocol {
     super.close();
 
     removeAllListeners();
-    stopRetryingToConnect = true;
     wasConnected = false;
 
     _subscription?.cancel();

--- a/lib/src/protocols/websocket_io.dart
+++ b/lib/src/protocols/websocket_io.dart
@@ -13,17 +13,20 @@ import 'events.dart';
 class KuzzleWebSocket extends KuzzleProtocol {
   KuzzleWebSocket(
     Uri uri, {
-    bool autoReconnect = true,
+    this.autoReconnect = true,
     Duration reconnectionDelay,
     this.pingInterval,
-  })  : 
-        super(uri,
-            autoReconnect: autoReconnect, reconnectionDelay: reconnectionDelay);
+  }) : super(uri) {
+    _reconnectionDelay = reconnectionDelay ?? Duration(seconds: 1);
+  }
 
   String _lastUrl;
   WebSocket _webSocket;
   StreamSubscription _subscription;
   Duration pingInterval;
+  Duration _reconnectionDelay;
+  bool autoReconnect;
+  bool _stopRetryingToConnect = false;
 
   @override
   Future<void> connect() async {
@@ -45,9 +48,10 @@ class KuzzleWebSocket extends KuzzleProtocol {
     try {
       _webSocket = await WebSocket.connect(url);
     } on IOException {
-      if (wasConnected) {
+      if (wasConnected || autoReconnect) {
         clientNetworkError(
             KuzzleError('WebSocketProtocol: Unable to connect to $url'));
+        _handleAutoReconnect();
 
         return;
       }
@@ -81,7 +85,7 @@ class KuzzleWebSocket extends KuzzleProtocol {
     super.close();
 
     removeAllListeners();
-    stopRetryingToConnect = true;
+    _stopRetryingToConnect = true;
     wasConnected = false;
 
     _subscription?.cancel();
@@ -103,12 +107,27 @@ class KuzzleWebSocket extends KuzzleProtocol {
     }
   }
 
+  void _handleAutoReconnect() {
+    if (autoReconnect && !retrying && !_stopRetryingToConnect) {
+      retrying = true;
+
+      Timer(_reconnectionDelay, () async {
+        retrying = false;
+        await connect().catchError(clientNetworkError);
+      });
+    } else {
+      emit(ProtocolEvents.DISCONNECT);
+    }
+  }
+
   void _handleDone() {
     if (_webSocket.closeCode == 1000) {
       clientDisconnected();
-    } else if (wasConnected) {
+    } else if (wasConnected || autoReconnect) {
+      clientDisconnected();
       clientNetworkError(KuzzleError(
           'clientNetworkError', _webSocket.closeReason, _webSocket.closeCode));
+      _handleAutoReconnect();
     }
   }
 }

--- a/lib/src/protocols/websocket_io.dart
+++ b/lib/src/protocols/websocket_io.dart
@@ -45,6 +45,8 @@ class KuzzleWebSocket extends KuzzleProtocol {
     await _webSocket?.close();
     _webSocket = null;
 
+    _stopRetryingToConnect = false;
+
     try {
       _webSocket = await WebSocket.connect(url);
     } on IOException {
@@ -65,7 +67,6 @@ class KuzzleWebSocket extends KuzzleProtocol {
         onError: _handleError, onDone: _handleDone);
 
     clientConnected();
-    _stopRetryingToConnect = false;
 
     unawaited(_webSocket.done.then((error) {
       clientNetworkError(

--- a/lib/src/protocols/websocket_io.dart
+++ b/lib/src/protocols/websocket_io.dart
@@ -65,6 +65,7 @@ class KuzzleWebSocket extends KuzzleProtocol {
         onError: _handleError, onDone: _handleDone);
 
     clientConnected();
+    _stopRetryingToConnect = false;
 
     unawaited(_webSocket.done.then((error) {
       clientNetworkError(

--- a/lib/src/protocols/websocket_io.dart
+++ b/lib/src/protocols/websocket_io.dart
@@ -37,6 +37,7 @@ class KuzzleWebSocket extends KuzzleProtocol {
     if (_hasBeenClosed && retrying) {
       return;
     }
+    _hasBeenClosed = false;
 
     final url = '${uri.scheme}://${uri.host}:${uri.port}';
 
@@ -74,7 +75,6 @@ class KuzzleWebSocket extends KuzzleProtocol {
     _subscription = _webSocket.listen(_handlePayload,
         onError: _handleError, onDone: _handleDone);
 
-    _hasBeenClosed = false;
     clientConnected();
 
     unawaited(_webSocket.done.then((error) {


### PR DESCRIPTION
## What does this PR do ?

fixes #83 

The `disconnected` event was not thrown in case of a manual disconnect.
Also the auto reconnection logic was not working. I moved the logic of the reconnection from the abstract protocol class to the actual websocket protocol and now call the `reconnected` event.
