### PR TITLE
[HOTFIX] Emit reconnect event after being reconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.0.1]
+
+- Bug fix: Fix a bug where the reconnect event would be emited before actually being reconnected
+
 ## [3.0.0]
 
 - Sound null safety compat

--- a/README.md
+++ b/README.md
@@ -21,16 +21,6 @@ You can access the Kuzzle repository on [Github](https://github.com/kuzzleio/kuz
 * [Documentation and Samples](#documentation-and-samples)
 * [Contribution](#contribution)
 
-## Installation
-
-Include this in your pubspec.yaml
-
-```yaml
-dependencies:
-  kuzzle: ^3.0.0
-
-```
-
 ## Documentation and Samples
 
 * [https://docs.kuzzle.io/sdk/dart/2/](https://docs.kuzzle.io/sdk/dart/2/) - 

--- a/lib/src/protocols/abstract.dart
+++ b/lib/src/protocols/abstract.dart
@@ -95,10 +95,11 @@ abstract class KuzzleProtocol extends KuzzleEventEmitter {
       return;
     }
 
-    emit(protocolState == KuzzleProtocolState.reconnecting
+    final protocolStateCpy = protocolState;
+    protocolState = KuzzleProtocolState.connected;
+    emit(protocolStateCpy == KuzzleProtocolState.reconnecting
         ? ProtocolEvents.RECONNECT
         : ProtocolEvents.CONNECT);
-    protocolState = KuzzleProtocolState.connected;
   }
 
   /// Called when the client's connection is closed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: kuzzle
-version: 3.0.0
+version: 3.0.1
 description: A library to interact with kuzzle API. A backend software,
   self-hostable and ready to use to power modern cross-platform apps.
 homepage: https://github.com/kuzzleio/sdk-dart


### PR DESCRIPTION
## What does this PR do ?

Fixes a bug where the "reconnect" event would be emitted slightly before actually being reconnected.
