### PR TITLE
fix : emit event on network error

### DIFF
--- a/.github/actions/doc-snippets/action.yml
+++ b/.github/actions/doc-snippets/action.yml
@@ -4,5 +4,5 @@ runs:
   using: "composite"
   steps:
     - name: Run Doc snippets Tests
-      run: docker-compose -f .ci/doc/docker-compose.yml run doc-tests index
+      run: docker compose -f .ci/doc/docker-compose.yml run doc-tests index
       shell: bash

--- a/.travis.old.yml
+++ b/.travis.old.yml
@@ -32,7 +32,7 @@ jobs:
       if: type = pull_request OR type = push AND branch =~ /^master|[0-9]+-dev$/ OR type = cron
       language: node_js
       node_js: 12
-      script: docker-compose -f .ci/doc/docker-compose.yml run doc-tests index
+      script: docker compose -f .ci/doc/docker-compose.yml run doc-tests index
 
 
     - stage: Tests

--- a/docker_launch.sh
+++ b/docker_launch.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 sysctl -w vm.max_map_count=262144
-docker-compose up -d
+docker compose up -d
 until curl "http://localhost:7512/?pretty"; do sleep 10; done
 ./adminauth.sh
 dart pub get

--- a/lib/src/kuzzle.dart
+++ b/lib/src/kuzzle.dart
@@ -189,7 +189,7 @@ class Kuzzle extends KuzzleEventEmitter {
         startQueuing();
       }
 
-      emit(ProtocolEvents.NETWORK_ERROR, [error]);
+      emit(KuzzleEvents.NETWORK_ERROR, [error]);
     });
 
     protocol.on(ProtocolEvents.DISCONNECT, () {

--- a/lib/src/kuzzle/events.dart
+++ b/lib/src/kuzzle/events.dart
@@ -8,4 +8,5 @@ class KuzzleEvents {
   static const String RECONNECTED = 'reconnected';
   static const String DISCONNECTED = 'disconnected';
   static const String QUERY_ERROR = 'queryError';
+  static const String NETWORK_ERROR = 'networkError';
 }


### PR DESCRIPTION

## What does this PR do ?
No event were triggered on network error. After a quick refactor we now have access to the event with `_kuzzle.on('networkError', () => {})`

### How should this be manually tested?

  - Step 1 : create a flutter project
  - Step 2 : test networkError event and other events
